### PR TITLE
add comment: UOS_KeyWait returns at signal

### DIFF
--- a/key.c
+++ b/key.c
@@ -92,6 +92,11 @@ int32 UOS_KeyPressed( void )
  *
  * \linux temporarily switches console to raw mode
  *
+ * \linux If a signal is caught while the call is executing then
+ * the call may return even without any keypress. Therefor, it
+ * is recommended to use instead UOS_KeyPressed() within a while loop
+ * until a character was received (!=-1).
+ *
  * \sa UOS_KeyPressed
  */
 int32 UOS_KeyWait( void )


### PR DESCRIPTION
**Attention: Create new doxygen documentation after the merge!**

Add a warning to the Linux specific UOS_KeyWait() documentation
that signals may abort the call.
Reason:
The m66_irq test program uses
    UOS_KeyWait();
to wait until a keypress.
But received MDIS signals abort the wait unexpectedly under Linux.
The problem was fixed by waiting with:
do {
      UOS_Delay(1i00);
} while (UOS_KeyPressed() == (-1));

Note: m66_irq.c is not yet included in
      https://github.com/MEN-Mikro-Elektronik/13M066-06
      but shall be in future.